### PR TITLE
Add ability to use .error, .warning and .success on .form-field

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -22,6 +22,15 @@
 	background-color: @input-bg;
 	border: 1px solid @input-border;
 	.round(@input-border-radius);
+    &.error {
+        border-color: @error;
+    }
+    &.warning {
+        border-color: @warning;
+    }
+    &.success {
+        border-color: @success;
+    }
 }
 
 .form-element {


### PR DESCRIPTION
I came up with the idea when using framy with a request form.
A red border is a good way to indicate a wrong input, while .warning and .success are also applicable.
