### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ __Demo / Documentation__ http://www.framycss.org/demo
 
 Just include a specific version like this:
 ```
-https://cdn.jsdelivr.net/framy/2.2/css/framy.min.css
+https://cdn.jsdelivr.net/gh/aaroniker/framy-css@2.2/dist/css/framy.min.css
 ```
 
 Or the latest release (7 days delayed):
 ```
-https://cdn.jsdelivr.net/framy/latest/css/framy.min.css
+https://cdn.jsdelivr.net/gh/aaroniker/framy-css@latest/dist/css/framy.min.css
 ```
 
 http://www.jsdelivr.com/projects/framy

--- a/README.md
+++ b/README.md
@@ -17,11 +17,6 @@ Just include a specific version like this:
 https://cdn.jsdelivr.net/gh/aaroniker/framy-css@2.2/dist/css/framy.min.css
 ```
 
-Or the latest release (7 days delayed):
-```
-https://cdn.jsdelivr.net/gh/aaroniker/framy-css@latest/dist/css/framy.min.css
-```
-
 http://www.jsdelivr.com/projects/framy
 
 ### Install with Bower


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/gh/aaroniker/framy-css.

Feel free to ping me if you have any questions regarding this change.